### PR TITLE
Add ESLint & Jest with mock service tests

### DIFF
--- a/__tests__/geminiService.test.ts
+++ b/__tests__/geminiService.test.ts
@@ -1,0 +1,34 @@
+import { evaluateAnswers } from '../services/geminiService';
+import { GoogleGenerativeAI } from '@google/genai';
+import type { Problem, SubmissionFormData } from '../types';
+
+jest.mock('@google/genai');
+
+describe('evaluateAnswers', () => {
+  it('parses AI response and returns evaluation result', async () => {
+    const mockGenerate = jest.fn().mockResolvedValue({
+      response: { text: () => Promise.resolve(JSON.stringify({
+        generalFeedback: 'good',
+        evaluations: [
+          { problemId: 'p1', score: 90, feedback: 'nice' },
+        ],
+      })) },
+    });
+
+    (GoogleGenerativeAI as jest.Mock).mockImplementation(() => ({
+      getGenerativeModel: () => ({ generateContent: mockGenerate }),
+    }));
+
+    const problems: Problem[] = [{ id: 'p1', title: 't', description: 'd' }];
+    const formData: SubmissionFormData = {
+      name: 's',
+      date: 'today',
+      answers: { p1: 'answer' },
+    };
+
+    const result = await evaluateAnswers(problems, formData);
+    expect(result.generalFeedback).toBe('good');
+    expect(result.evaluations.p1.score).toBe(90);
+    expect(mockGenerate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/googleDriveService.test.ts
+++ b/__tests__/googleDriveService.test.ts
@@ -1,0 +1,25 @@
+import { createStudentSheet } from '../services/googleDriveService';
+import type { Submission } from '../types';
+
+declare const global: any;
+
+describe('createStudentSheet', () => {
+  it('creates sheet and returns URL', async () => {
+    const mockCreate = jest.fn().mockResolvedValue({ result: { webViewLink: 'url' } });
+    global.gapi = { client: { drive: { files: { create: mockCreate } } } };
+
+    const submission = {
+      id: '1',
+      name: 'Jane',
+      date: '2024-01-01',
+      submittedAt: new Date(),
+      answers: {},
+      problems: [],
+      evaluation: { generalFeedback: '', evaluations: {} },
+    } as Submission;
+
+    const result = await createStudentSheet(submission);
+    expect(result.sheetUrl).toBe('url');
+    expect(mockCreate).toHaveBeenCalled();
+  });
+});

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  languageOptions: {
+    parser: '@typescript-eslint/parser',
+  },
+  plugins: {
+    '@typescript-eslint': require('@typescript-eslint/eslint-plugin'),
+    react: require('eslint-plugin-react'),
+  },
+  rules: {},
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  linterOptions: {
+    reportUnusedDisableDirectives: true,
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react-dom": "^19.1.0",
@@ -16,6 +17,14 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^6.8.0",
+    "@typescript-eslint/eslint-plugin": "^6.8.0",
+    "eslint-plugin-react": "^7.33.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,0 +1,24 @@
+import { GoogleGenerativeAI } from '@google/genai';
+import type { Problem, SubmissionFormData, Evaluation, EvaluationResult, AiEvaluationResponse } from '../types';
+
+export async function evaluateAnswers(problems: Problem[], formData: SubmissionFormData): Promise<EvaluationResult> {
+  const apiKey = process.env.GEMINI_API_KEY || '';
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+
+  const prompt = problems.map(p => `Q:${p.description}\nA:${formData.answers[p.id] || ''}`).join('\n');
+
+  const result = await model.generateContent(prompt);
+  const text = await result.response.text();
+  const ai: AiEvaluationResponse = JSON.parse(text);
+
+  const evaluations: Record<string, Evaluation> = {};
+  for (const e of ai.evaluations) {
+    evaluations[e.problemId] = { score: e.score, feedback: e.feedback };
+  }
+
+  return {
+    generalFeedback: ai.generalFeedback,
+    evaluations,
+  };
+}

--- a/services/googleDriveService.ts
+++ b/services/googleDriveService.ts
@@ -1,0 +1,20 @@
+import type { Submission } from '../types';
+
+export async function createStudentSheet(submission: Submission): Promise<{ sheetUrl: string }> {
+  const gapi = (global as any).gapi || (window as any).gapi;
+  if (!gapi || !gapi.client) {
+    throw new Error('Google API client not loaded');
+  }
+
+  const metadata = {
+    name: `${submission.name}-${submission.date}.xlsx`,
+    mimeType: 'application/vnd.google-apps.spreadsheet',
+  };
+
+  const response = await gapi.client.drive.files.create({
+    resource: metadata,
+    fields: 'webViewLink',
+  });
+
+  return { sheetUrl: response.result.webViewLink };
+}


### PR DESCRIPTION
## Summary
- add ESLint config for TypeScript/React projects
- configure Jest with ts-jest
- implement `evaluateAnswers` and `createStudentSheet` service utilities
- provide unit tests mocking Gemini and Google Drive APIs

## Testing
- `npm test` *(fails: jest not found)*
- `npx eslint .` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_687b1b35834483279cc48aa3075963e1